### PR TITLE
自動広告スキップを設定に合わせて作動させる

### DIFF
--- a/src/modules/queries.ts
+++ b/src/modules/queries.ts
@@ -3,5 +3,5 @@ export const adSkipButton: Array<string> = [
   '[skip-advertisement="true"] .adSkipButton',
 
   // Windows
-  '.atvwebplayersdk-infobar-container > div:nth-child(1) > div:nth-child(3) > div:nth-child(2)',
+  '[skip-advertisement="true"] .atvwebplayersdk-infobar-container > div:nth-child(1) > div:nth-child(3) > div:nth-child(2)',
 ]


### PR DESCRIPTION
fix #2  

# 概要

Windows環境で自動広告スキップをOFFにしていても広告がスキップされる現象を解消

# 詳細

広告スキップ用ボタンを識別するクエリを更新